### PR TITLE
Resolve --output-dir and --resume-dir to absolute paths

### DIFF
--- a/loca/cli/commands/run.py
+++ b/loca/cli/commands/run.py
@@ -276,7 +276,7 @@ def run_command(
 
     # Build output directory
     if output_dir:
-        final_output_dir = Path(output_dir)
+        final_output_dir = Path(output_dir).resolve()
     else:
         try:
             final_output_dir = build_output_dir(

--- a/loca/cli/utils/output_builder.py
+++ b/loca/cli/utils/output_builder.py
@@ -170,7 +170,7 @@ def build_output_dir(
             pass  # Fall through to build path without timestamp
         else:
             # Use provided path directly
-            output_path = Path(resume_dir)
+            output_path = Path(resume_dir).resolve()
             if not output_path.is_dir():
                 raise FileNotFoundError(
                     f"Resume directory does not exist: {output_path}"


### PR DESCRIPTION
Several env preprocessing pipelines spawn subprocesses with cwd=env_dir (e.g. canvas_arrange_exam_s2l/main.py:248) and pass task_dir through argv. When the user supplies a relative --output-dir, task_dir stays relative, so the subprocess resolves it against the env directory while the in-process setup resolves it against the shell cwd. The two paths diverge: generated configs land under gem/envs/<env>/<output-dir>/..., while the in-process loaders look under <cwd>/<output-dir>/..., silently fail to load, and leave the local mock DB empty. Tasks then run against empty Canvas/Email data and accuracy collapses.

Resolving the user-supplied path once at the CLI layer guarantees every downstream consumer sees the same absolute path, regardless of any cwd changes inside env preprocessing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to path handling in the CLI/output builder; main risk is minor behavior differences for users relying on relative paths.
> 
> **Overview**
> Normalizes user-supplied directory arguments so downstream code always receives an absolute path.
> 
> `loca run` now resolves `--output-dir` via `Path(...).resolve()`, and `build_output_dir()` similarly resolves an explicitly provided `--resume-dir` before validating it exists, preventing divergence when subprocesses change `cwd`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 256c2f5a820debb79ddf3e2111436ec600cded0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->