### PR TITLE
Pin mcp<2 for MCP servers broken by the mcp 2.0 release

### DIFF
--- a/gem/tools/mcp_server/config/terminal.yaml
+++ b/gem/tools/mcp_server/config/terminal.yaml
@@ -6,6 +6,8 @@ description: Terminal command execution server with security controls
 execution:
   command_type: uvx
   package_name: "cli-mcp-server"
+  with_requirements:
+    - "mcp<2"
 
 parameters:
   agent_workspace:

--- a/gem/tools/mcp_server/config_loader.py
+++ b/gem/tools/mcp_server/config_loader.py
@@ -183,7 +183,10 @@ class ServerConfigLoader:
         if not package_name:
             raise ValueError("uvx command_type requires 'package_name' in execution config")
 
-        args = [package_name]
+        args = []
+        for requirement in execution.get("with_requirements", []):
+            args.extend(["--with", requirement])
+        args.append(package_name)
         args.extend(self._build_cli_args(config, params))
 
         return "uvx", args

--- a/mcp_convert/pyproject.toml
+++ b/mcp_convert/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "MCP Convert", email = "mcp@example.com"},
 ]
 dependencies = [
-    "mcp>=1.9.0",
+    "mcp>=1.9.0,<2",
     "pandas>=1.5.0",
 ]
 requires-python = ">=3.12"

--- a/mcp_convert/requirements.txt
+++ b/mcp_convert/requirements.txt
@@ -1,3 +1,3 @@
-mcp>=1.0.0
+mcp>=1.0.0,<2
 pandas>=1.5.0
 asyncio


### PR DESCRIPTION
cli-mcp-server 0.2.x uses the mcp 1.x low-level Server API, and the mcp_convert servers are written against mcp 1.x; an unconstrained resolve now pulls mcp 2.0.0 and the servers crash at startup.

- config_loader: support execution.with_requirements in uvx configs, emitted as `uvx --with <spec>` to pin transitive dependencies
- terminal.yaml: pin "mcp<2" for cli-mcp-server via with_requirements
- mcp_convert: constrain mcp to <2 in pyproject.toml/requirements.txt
